### PR TITLE
이서연 6회차 풀이 제출

### DIFF
--- a/이서연/6회차/Boj13459_구슬_탈출.java
+++ b/이서연/6회차/Boj13459_구슬_탈출.java
@@ -1,0 +1,150 @@
+package boj.g1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj13459_구슬_탈출 {
+	static int[] di = { -1, 1, 0, 0 };
+	static int[] dj = { 0, 0, -1, 1 };
+	static int N, M, hi, hj;
+	static char[][] board;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		board = new char[N][];
+		int ri = -1;
+		int rj = -1;
+		int bi = -1;
+		int bj = -1;
+		hi = -1;
+		hj = -1;
+		for (int i = 0; i < N; i++) {
+			board[i] = br.readLine().toCharArray();
+			for (int j = 0; j < M; j++) {
+				if (board[i][j] == 'R') {
+					ri = i;
+					rj = j;
+					board[i][j] = '.';
+				} else if (board[i][j] == 'B') {
+					bi = i;
+					bj = j;
+					board[i][j] = '.';
+				} else if (board[i][j] == 'O') {
+					hi = i;
+					hj = j;
+				}
+			}
+		}
+
+		System.out.println(bfs(ri, rj, bi, bj));
+	}
+
+	private static int bfs(int ri, int rj, int bi, int bj) {
+		Queue<int[]> queue = new LinkedList<>();
+		queue.add(new int[] { ri, rj, bi, bj });
+
+		int[] now, next;
+		int size;
+		int cnt = 0;
+		while (!queue.isEmpty()) {
+			size = queue.size();
+
+			if (cnt > 10)
+				return 0;
+
+			for (int s = 0; s < size; s++) {
+				now = queue.poll();
+//				System.out.println(cnt+"번째: "+ Arrays.toString(now));
+				if (now[2] == hi && now[3] == hj) { // 파란 구슬이 구멍에 들어가는 경우
+					continue;
+				}
+				if (now[0] == hi && now[1] == hj) { // 빨간 구슬을 10번 이하로 움직여서 구멍에 넣는 경우
+					return 1;
+				}
+				for (int d = 0; d < 4; d++) {
+					next = moveBoard(now, d);
+					if (now[0] == next[0] && now[1] == next[1] && now[2] == next[2] && now[3] == next[3])
+						continue;
+					queue.add(next);
+				}
+			}
+			cnt++;
+		}
+		return 0;
+	}
+
+	private static int[] moveBoard(int[] now, int dir) {
+		int ri = now[0];
+		int rj = now[1];
+		int bi = now[2];
+		int bj = now[3];
+
+		int next_ri, next_rj, next_bi, next_bj;
+
+		while (true) {
+			next_ri = ri + di[dir];
+			next_rj = rj + dj[dir];
+
+			if (next_ri < 0 || next_ri >= N || next_rj < 0 || next_rj >= M || board[next_ri][next_rj] == '#') {
+				break;
+			}
+			ri = next_ri;
+			rj = next_rj;
+
+			if (board[ri][rj] == 'O')
+				break;
+		}
+
+		while (true) {
+			next_bi = bi + di[dir];
+			next_bj = bj + dj[dir];
+
+			if (next_bi < 0 || next_bi >= N || next_bj < 0 || next_bj >= M || board[next_bi][next_bj] == '#') {
+				break;
+			}
+			bi = next_bi;
+			bj = next_bj;
+
+			if (board[bi][bj] == 'O')
+				break;
+		}
+
+		if ((ri == bi && rj == bj) && !(ri == hi && rj == hj)) { // 동시에 구멍에 들어가는 경우는 그대로
+			switch (dir) {
+			case 0:
+				if (now[0] < now[2])
+					bi++;
+				else
+					ri++;
+				break;
+			case 1:
+				if (now[0] < now[2])
+					ri--;
+				else
+					bi--;
+				break;
+			case 2:
+				if (now[1] < now[3])
+					bj++;
+				else
+					rj++;
+				break;
+			case 3:
+				if (now[1] < now[3])
+					rj--;
+				else
+					bj--;
+				break;
+			}
+		}
+		return new int[] { ri, rj, bi, bj };
+	}
+}

--- a/이서연/6회차/Boj5430_AC.java
+++ b/이서연/6회차/Boj5430_AC.java
@@ -1,0 +1,81 @@
+package boj.g5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Boj5430_AC {
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+
+		int TC = Integer.parseInt(br.readLine());
+		for (int tc = 0; tc < TC; tc++) {
+			char[] p = br.readLine().toCharArray();
+			int n = Integer.parseInt(br.readLine());
+			char[] input = br.readLine().toCharArray();
+			int[] numArr = new int[n];
+
+			int idx = 0;
+			int num = 0;
+			for (int i = 1; i < input.length; i++) {
+				if (input[i] >= '0' && input[i] <= '9') {
+					num = num * 10 + (input[i] - '0');
+				} else if (input[i] == ',' || input[i] == ']') {
+					if (num != 0) { // 입력되는 수는 1 이상 (0이면 저장하지 않음)
+						numArr[idx] = num;
+						idx++;
+						num = 0;
+					}
+					if (input[i] == ']')
+						break;
+				}
+			}
+
+			boolean reverse = false;
+			boolean result = true;
+			int si = 0;
+			int ei = n - 1;
+			for (int i = 0; i < p.length; i++) {
+				if (p[i] == 'R') {
+					reverse = !reverse;
+				} else if (p[i] == 'D') {
+					if (si > ei) {
+						result = false;
+						break;
+					}
+					if (reverse) {
+						ei--;
+					} else {
+						si++;
+					}
+				}
+			}
+
+			if (!result) {
+				sb.append("error");
+			} else {
+				sb.append('[');
+				if (!reverse) {
+					for (int i = si; i <= ei; i++) {
+						sb.append(numArr[i]);
+						if (i != ei) {
+							sb.append(',');
+						}
+					}
+				} else {
+					for (int i = ei; i >= si; i--) {
+						sb.append(numArr[i]);
+						if (i != si) {
+							sb.append(',');
+						}
+					}
+				}
+				sb.append(']');
+			}
+			sb.append('\n');
+		}
+
+		System.out.println(sb.toString());
+	}
+}

--- a/이서연/6회차/Boj7662_이중_우선순위_큐.java
+++ b/이서연/6회차/Boj7662_이중_우선순위_큐.java
@@ -1,0 +1,52 @@
+package boj.g4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.TreeMap;
+
+public class Boj7662_이중_우선순위_큐 {
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		StringTokenizer st;
+		char op;
+		int K, n;
+		StringBuilder sb = new StringBuilder();
+
+		for (int t = 0; t < T; t++) {
+			K = Integer.parseInt(br.readLine());
+			TreeMap<Integer, Integer> queue = new TreeMap<>();
+
+			for (int k = 0; k < K; k++) {
+				st = new StringTokenizer(br.readLine());
+				op = st.nextToken().charAt(0);
+				n = Integer.parseInt(st.nextToken());
+
+				if (op == 'I') { // 삽입
+					queue.put(n, queue.getOrDefault(n, 0) + 1);
+				} else if (op == 'D' && !queue.isEmpty()) { // 삭제
+					int key;
+					if (n == 1) { // 최댓값 삭제
+						key = queue.lastKey();
+					} else { // 최솟값 삭제
+						key = queue.firstKey();
+					}
+
+					if (queue.get(key) == 1)
+						queue.remove(key);
+					else
+						queue.put(key, queue.get(key) - 1);
+				}
+			}
+
+			if (queue.isEmpty()) {
+				sb.append("EMPTY").append("\n");
+			} else {
+				sb.append(queue.lastKey()).append(" ").append(queue.firstKey()).append("\n");
+			}
+		}
+		System.out.println(sb.toString());
+	}
+}

--- a/이서연/6회차/Boj9019_DSLR.java
+++ b/이서연/6회차/Boj9019_DSLR.java
@@ -1,0 +1,93 @@
+package boj.g4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj9019_DSLR {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		boolean[] visited;
+		for (int t = 0; t < T; t++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int A = Integer.parseInt(st.nextToken());
+			int B = Integer.parseInt(st.nextToken());
+
+			Queue<Result> queue = new ArrayDeque<>();
+			queue.add(new Result(A, ""));
+			visited = new boolean[10000];
+			visited[A] = true;
+
+			while (!queue.isEmpty()) {
+				Result now = queue.poll();
+
+				if (now.num == B) {
+					System.out.println(now.cmd);
+					break;
+				}
+
+				int next = D(now.num);
+				if (!visited[next]) {
+					queue.add(new Result(next, now.cmd + 'D'));
+					visited[next] = true;
+				}
+				next = S(now.num);
+				if (!visited[next]) {
+					queue.add(new Result(next, now.cmd + 'S'));
+					visited[next] = true;
+				}
+				next = L(now.num);
+				if (!visited[next]) {
+					queue.add(new Result(next, now.cmd + 'L'));
+					visited[next] = true;
+				}
+				next = R(now.num);
+				if (!visited[next]) {
+					queue.add(new Result(next, now.cmd + 'R'));
+					visited[next] = true;
+				}
+			}
+		}
+	}
+
+	static class Result {
+		int num;
+		String cmd;
+
+		public Result(int num, String cmd) {
+			super();
+			this.num = num;
+			this.cmd = cmd;
+		}
+	}
+
+	static int D(int n) {
+		int num = 2 * n;
+		num = num % 10000;
+
+		return num;
+	}
+
+	static int S(int n) {
+		int num = n == 0 ? 9999 : n - 1;
+
+		return num;
+	}
+
+	static int L(int n) {
+		int temp = n % 1000;
+		int num = temp * 10 + n / 1000;
+
+		return num;
+	}
+
+	static int R(int n) {
+		int temp = n % 10;
+		int num = n / 10 + temp * 1000;
+		return num;
+	}
+}


### PR DESCRIPTION
## 📝 문제 내용
1. [BOJ 5430 AC](https://www.acmicpc.net/problem/5430)
2. [BOJ 9019 DSLR](https://www.acmicpc.net/problem/9019)
3. [BOJ 7662 이중 우선순위 큐](https://www.acmicpc.net/problem/7662)
4. [BOJ 13459 구슬 탈출](https://www.acmicpc.net/problem/13459)

## 📊 문제 분석
1. 정수 배열이 주어질 때, 뒤집기 연산과 버리기 연산 수행
2. 정수 A를 B로 변환하기 위해 필요한 최소한의 명령어(DSLR) 나열 구하기
3. 데이터를 삭제할 때 우선순위가 가장 높거나 가장 낮은 데이터를 삭제하는 이중 우선순위 큐의 연산 처리
4. 보드의 상태가 주어질 때 기울여서 빨간 구슬을 구멍에 넣을 수 있는지 구하기

## 🧨 사용 알고리즘
1. 문자열 파싱, 배열 인덱스 활용
2. BFS
3. TreeMap
4. BFS, 구현

## ✨ 느낀점 & 피드백
- 그래프 탐색할 때 방문 체크 해야하는지, 어디에서 해야하는지 좀더 생각하고 문제 풀기
- 이중 우선순위 큐는 시간초과 해결 못해서 다른 풀이 참고해서 풀었습니다..! (트리맵 사용법 알아두기)
- 구현 문제 조건 꼼꼼히 읽기
