### PR TITLE
강수민 6회차 풀이 제출

### DIFF
--- a/강수민/6회차/Boj_13459_구슬_탈출.java
+++ b/강수민/6회차/Boj_13459_구슬_탈출.java
@@ -1,0 +1,128 @@
+package G1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj_13459_구슬_탈출 {
+    private static char[][] map;
+    private static int[] dx = {-1, 0, 1, 0};
+    private static int[] dy = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        // Input
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        map = new char[N][M];
+        int[] start = new int[4];
+        for (int i = 0; i < N; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < M; j++) {
+                char c = s.charAt(j);
+                if (c == 'R') {
+                    start[0] = i;
+                    start[1] = j;
+                    map[i][j] = '.';
+                } else if (c == 'B') {
+                    start[2] = i;
+                    start[3] = j;
+                    map[i][j] = '.';
+                } else {
+                    map[i][j] = c;
+                }
+            }
+        }
+
+        // BFS + Output
+        System.out.println(bfs(start));
+    }
+
+    private static int bfs(int[] start) {
+        Queue<int[]> que = new ArrayDeque<>();
+        que.add(start);
+        int cnt = 1;
+        while (!que.isEmpty() && cnt <= 10) {
+            int size = que.size();
+            for (int i = 0; i < size; i++) {
+                int[] points = que.poll();
+                for (int j = 0; j < 4; j++) {
+                    int[] result = new int[4];      // 굴렸을때 공 위치
+                    int ret = go(j, points, result);   // 공 굴려보기
+                    if (ret == 1) return 1;         // 정답 찾음
+                    else if (ret == 0) {            // 진행은 가능
+                        que.add(result);
+                    }
+                }
+            }
+            cnt++;
+        }
+        return 0;
+    }
+
+    private static int go(int d, int[] points, int[] result) {
+        boolean red = false, blue = false;
+        int rx = points[0];
+        int ry = points[1];
+        int bx = points[2];
+        int by = points[3];
+
+//        System.out.println(rx + " " + ry + " " + bx + " " + by + " " + d);
+
+        // 빨간 공 굴리기
+        while (map[rx + dx[d]][ry + dy[d]] != '#') {
+            rx += dx[d];
+            ry += dy[d];
+            if (map[rx][ry] == 'O') {
+                red = true;
+                break;
+            }
+//            System.out.println(rx + " " + ry);
+        }
+
+        // 파란 공 굴리기
+        while (map[bx + dx[d]][by + dy[d]] != '#') {
+            bx += dx[d];
+            by += dy[d];
+            if (map[bx][by] == 'O') {
+                blue = true;
+                break;
+            }
+        }
+
+        if (blue) return 2;         // 파란공 들어가버림 (진행불가)
+        else if (red) return 1;     // 빨간 공만 들어감 (성공)
+        else {                      // 둘 다 안들어감 (계속 진행)
+            if (rx == bx && ry == by) {  // 두 공이 겹침
+                if (first(d, points)) {      // 빨간 공이 빠름
+                    bx += dx[(d + 2) % 4];
+                    by += dy[(d + 2) % 4];
+                } else {                    // 파란 공이 빠름
+                    rx += dx[(d + 2) % 4];
+                    ry += dy[(d + 2) % 4];
+                }
+            }
+            result[0] = rx;
+            result[1] = ry;
+            result[2] = bx;
+            result[3] = by;
+            return 0;
+        }
+    }
+
+    private static boolean first(int d, int[] points) {
+        if (d == 0) {
+            return points[0] < points[2];
+        } else if (d == 1) {
+            return points[1] > points[3];
+        } else if (d == 2) {
+            return points[0] > points[2];
+        } else {
+            return points[1] < points[3];
+        }
+    }
+}

--- a/강수민/6회차/Boj_5430_AC.java
+++ b/강수민/6회차/Boj_5430_AC.java
@@ -1,0 +1,77 @@
+package G5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Boj_5430_AC {
+    public static void main(String[] args) throws IOException {
+        // Input
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int tc = Integer.parseInt(br.readLine());
+
+        for (int t = 0; t < tc; t++) {
+            String p = br.readLine();
+            int n = Integer.parseInt(br.readLine());
+            String origin = br.readLine();
+            String[] ss = origin.substring(1, origin.length() - 1).split(",");
+
+            int[] arr = new int[n];
+            for (int i = 0; i < n; i++) {
+                arr[i] = Integer.parseInt(ss[i]);
+            }
+
+            // 중복 R 제거
+            while (p.contains("RR")) {
+                p = p.replace("RR", "");
+            }
+
+            // 연산 수행
+            process(n, p, arr);
+        }
+    }
+
+    private static void process(int n, String p, int[] arr) {
+        int left = 0, right = n - 1;
+        boolean flag = true;
+
+        for (int i = 0; i < p.length(); i++) {
+            // 뒤집기
+            if (p.charAt(i) == 'R') {
+                flag = !flag;
+            }
+            // 맨 앞 지우기
+            else {
+                if (n == 0) {
+                    System.out.println("error");
+                    return;
+                }
+                n--;
+                if (flag) left++;
+                else right--;
+            }
+        }
+
+        if (n==0) {
+            System.out.println("[]");
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+
+        if (flag) {
+            for (int i = left; i <= right; i++) {
+                sb.append(arr[i]).append(',');
+            }
+        } else {
+            for (int i = right; i >= left; i--) {
+                sb.append(arr[i]).append(',');
+            }
+        }
+
+        sb.deleteCharAt(sb.length() - 1);
+        sb.append(']');
+        System.out.println(sb);
+    }
+}

--- a/강수민/6회차/Boj_7662_이중_우선순위_큐.java
+++ b/강수민/6회차/Boj_7662_이중_우선순위_큐.java
@@ -1,0 +1,76 @@
+package G4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj_7662_이중_우선순위_큐 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st = null;
+        // TestCase
+        int T = Integer.parseInt(br.readLine());
+        for (int t = 0; t < T; t++) {
+            // Input
+            int k = Integer.parseInt(br.readLine());
+            Queue<Integer> max_pq = new PriorityQueue<>(k, Collections.reverseOrder());
+            Queue<Integer> min_pq = new PriorityQueue<>(k);
+            Map<Integer, Integer> map = new HashMap<>();
+
+            for (int i = 0; i < k; i++) {
+                st = new StringTokenizer(br.readLine());
+                char order = st.nextToken().charAt(0);
+                int num = Integer.parseInt(st.nextToken());
+                // Orders
+                if (order == 'I') { // Inque
+                    max_pq.add(num);
+                    min_pq.add(num);
+                    map.put(num, map.getOrDefault(num, 0) + 1);
+                } else {            // Deque
+                    if (num == 1) {     // max_pq deque
+                        deque(max_pq, map);
+                    } else {            // min_pq deque
+                        deque(min_pq, map);
+                    }
+                }
+            }
+            int max = Integer.MIN_VALUE;
+            int min = Integer.MAX_VALUE;
+            boolean flag = true;
+
+            for (int key : map.keySet()) {
+                int num = map.get(key);
+                if (num > 0) {
+                    flag = false;
+                    max = Math.max(max, key);
+                    min = Math.min(min, key);
+                }
+            }
+
+            if (flag) {
+                sb.append("EMPTY").append('\n');
+            } else {
+                sb.append(max).append(' ').append(min).append('\n');
+            }
+        }
+        System.out.print(sb);
+    }
+
+    private static void deque(Queue<Integer> queue, Map<Integer, Integer> map) {
+        while (!queue.isEmpty()) {
+            int num = queue.poll();
+
+            if (map.get(num) > 0) {
+                map.put(num, map.get(num) - 1);
+                break;
+            }
+        }
+    }
+}

--- a/강수민/6회차/Boj_9019_DSLR.java
+++ b/강수민/6회차/Boj_9019_DSLR.java
@@ -1,0 +1,83 @@
+package G4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Boj_9019_DSLR {
+    private static class DSLR {
+        String history;
+        int num;
+
+        public DSLR(int num, String history) {
+            this.num = num;
+            this.history = history;
+        }
+    }
+
+    private static final int MAX = 10_000;
+
+    public static void main(String[] args) throws IOException {
+        // Input
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st = null;
+
+        for (int t = 0; t < T; t++) {
+            st = new StringTokenizer(br.readLine());
+            int A = Integer.parseInt(st.nextToken());
+            int B = Integer.parseInt(st.nextToken());
+            boolean[] visited = new boolean[MAX];
+
+            // BFS
+            Queue<DSLR> que = new ArrayDeque<>();
+            que.offer(new DSLR(A, ""));
+
+            while (!que.isEmpty()) {
+                DSLR dslr = que.poll();
+                int num = dslr.num;
+                String history = dslr.history;
+
+                // B발견하면 종료
+                if (num == B) {
+                    sb.append(history).append('\n');
+                    break;
+                }
+
+                if (!visited[num]) {
+                    visited[num] = true;
+
+                    // D 연산
+                    int temp = (num * 2) % MAX;
+                    if (!visited[temp]) {
+                        que.offer(new DSLR(temp, history + 'D'));
+                    }
+
+                    // S 연산
+                    temp = num == 0 ? 9999 : num - 1;
+                    if (!visited[temp]) {
+                        que.offer(new DSLR(temp, history + 'S'));
+                    }
+
+                    // L 연산
+                    temp = (num * 10) % 10000 + num / 1000;
+                    if (!visited[temp]) {
+                        que.offer(new DSLR(temp, history + 'L'));
+                    }
+
+                    // R 연산
+                    temp = num / 10 + num % 10 * 1000;
+                    if (!visited[temp]) {
+                        que.offer(new DSLR(temp, history + 'R'));
+                    }
+                }
+            }
+        }
+        // Output
+        System.out.println(sb);
+    }
+}

--- a/강수민/README.md
+++ b/강수민/README.md
@@ -1,12 +1,43 @@
 # 🍀강수민 제출 페이지
+
 ## [1회차 (23.02.06 ~ 23.02.12)](https://github.com/ssafy9-dj5/CT_Study_for_Gold/pull/2)
-- [1번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ2312-%EC%88%98-%EB%B3%B5%EC%9B%90%ED%95%98%EA%B8%B0)
-- [2번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ7507-%EC%98%AC%EB%A6%BC%ED%94%BD-%EA%B2%8C%EC%9E%84)
-- [3번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ1992-%EC%BF%BC%EB%93%9C%ED%8A%B8%EB%A6%AC)
-- [4번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ1954-%ED%99%94%ED%95%99%EC%8B%A4%ED%97%98)
+
+- [1번 '수 복원하기' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ2312-%EC%88%98-%EB%B3%B5%EC%9B%90%ED%95%98%EA%B8%B0)
+- [2번 '올림픽 게임' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ7507-%EC%98%AC%EB%A6%BC%ED%94%BD-%EA%B2%8C%EC%9E%84)
+- [3번 '쿼드트리' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1992-%EC%BF%BC%EB%93%9C%ED%8A%B8%EB%A6%AC)
+- [4번 '화학실험' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1954-%ED%99%94%ED%95%99%EC%8B%A4%ED%97%98)
 
 ## [2회차 (23.02.13 ~ 23.02.19)](https://github.com/ssafy9-dj5/CT_Study_for_Gold/pull/14)
-- [1번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ19621-%ED%9A%8C%EC%9D%98%EC%8B%A4-%EB%B0%B0%EC%A0%95-2)
-- [2번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ14888-%EC%97%B0%EC%82%B0%EC%9E%90-%EB%81%BC%EC%9B%8C%EB%84%A3%EA%B8%B0)
-- [3번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ12865-%ED%8F%89%EB%B2%94%ED%95%9C-%EB%B0%B0%EB%82%AD)
-- [4번 문제 포스팅 링크](https://soooom.tistory.com/entry/BOJ17281-%E2%9A%BE)
+
+- [1번 '회의실 배정 2' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ19621-%ED%9A%8C%EC%9D%98%EC%8B%A4-%EB%B0%B0%EC%A0%95-2)
+- [2번 '연산자 끼워넣기' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ14888-%EC%97%B0%EC%82%B0%EC%9E%90-%EB%81%BC%EC%9B%8C%EB%84%A3%EA%B8%B0)
+- [3번 '평범한 배낭' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ12865-%ED%8F%89%EB%B2%94%ED%95%9C-%EB%B0%B0%EB%82%AD)
+- [4번 '⚾' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ17281-%E2%9A%BE)
+
+## [3회차 (23.02.20 ~ 23.02.26](https://github.com/ssafy9-dj5/CT_Study_for_Gold/pull/19)
+
+- [1번 '섬의 개수' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ4963-%EC%84%AC%EC%9D%98-%EA%B0%9C%EC%88%98)
+- [2번 '그림' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1926-%EA%B7%B8%EB%A6%BC)
+- [3번 '트리' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1068-%ED%8A%B8%EB%A6%AC)
+- [4번 '미세먼지 안녕!' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ17144-%EB%AF%B8%EC%84%B8%EB%A8%BC%EC%A7%80-%EC%95%88%EB%85%95)
+
+## [4회차 (23.02.27 ~ 23.03.05)](https://github.com/ssafy9-dj5/CT_Study_for_Gold/pull/26)
+
+- [1번 '스타트와 링크' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ14889-%EC%8A%A4%ED%83%80%ED%8A%B8%EC%99%80-%EB%A7%81%ED%81%AC)
+- [2번 '하노이 탑' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1914-%ED%95%98%EB%85%B8%EC%9D%B4-%ED%83%91)
+- [3번 '파이프 옮기기 1' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ17070-%ED%8C%8C%EC%9D%B4%ED%94%84-%EC%98%AE%EA%B8%B0%EA%B8%B0-1)
+- [4번 '연구소' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ14502-%EC%97%B0%EA%B5%AC%EC%86%8C)
+
+## [5회차 (23.03.06 ~ 23.03.12)](https://github.com/ssafy9-dj5/CT_Study_for_Gold/pull/32)
+
+- [1번 '집합의 표현' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1717-%EC%A7%91%ED%95%A9%EC%9D%98-%ED%91%9C%ED%98%84)
+- [2번 '최소비용 구하기' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ1916-%EC%B5%9C%EC%86%8C%EB%B9%84%EC%9A%A9-%EA%B5%AC%ED%95%98%EA%B8%B0)
+- [3번 '뱀과 사다리 게임' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ16928-%EB%B1%80%EA%B3%BC-%EC%82%AC%EB%8B%A4%EB%A6%AC-%EA%B2%8C%EC%9E%84)
+- [4번 '낚시왕'](https://soooom.tistory.com/entry/BOJ17143-%EB%82%9A%EC%8B%9C%EC%99%95)
+
+## [6회차 (23.03.13 ~ 23.03.26)](https://github.com/ssafy9-dj5/CT_Study_for_Gold/pull/42)
+
+- [1번 'AC' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ5430-AC)
+- [2번 'DSLR' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ9019-DSLR)
+- [3번 '이중 우선순위 큐' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ7662-%EC%9D%B4%EC%A4%91-%EC%9A%B0%EC%84%A0%EC%88%9C%EC%9C%84-%ED%81%90)
+- [4번 '구슬 탈출' 풀이 포스팅](https://soooom.tistory.com/entry/BOJ13459-%EA%B5%AC%EC%8A%AC-%ED%83%88%EC%B6%9C)


### PR DESCRIPTION
## 📝 문제 내용
1. [BOJ 5430 AC](https://www.acmicpc.net/problem/5430)
2. [BOJ 9019 DSLR](https://www.acmicpc.net/problem/9019)
3. [BOJ 7662 이중 우선순위 큐](https://www.acmicpc.net/problem/7662)
4. [BOJ 13459 구슬 탈출](https://www.acmicpc.net/problem/13459)

## 📊 문제 분석
1. 문자열 삭제, 뒤집기
2. 4가지 연산으로 정수 A를 정수 B로 만드는 최소 연산 회수의 연산 방법 구하기
3. 힙 정렬을 이용한 최대, 최소값 반복 삭제
4. 보드판에서 두 구슬을 굴려 빨간 공만 꺼낼 수 있는지 확인

## 🧨 사용 알고리즘
1. 중복 연산 제거, 투 포인터
2. BFS, 정수 %연산
3. 최대힙, 최소힙 두 가지 우선순위 큐와 공통 인수를 저장한 맵 사용
4. BFS, 시뮬레이션

## ✨ 느낀점 & 피드백
- 이번 4 문제는 처음 풀이는 개선 할 부분이 많이 있었다.
  - 1번은 문자열 뒤집기를 자료구조로 해보려다 시간초과가 나서 투 포인터로 바꿨다.
  - 2번은 정수를 deque로 만들어 shift를 구현하려다 시간 초과가 났다. 정수 모듈러 연산으로 해결했다.
  - 3번은 두 우선순위 큐와 맵 하나를 사용했는데, java의 TreeMap을 사용하면 레드블랙 트리로 최대값과 최소값을 빠르게 찾을 수 있다.
  - 4번은 DFS로 접근했다가 코드가 너무 꼬여서 BFS로 수정했다.
- 다른 풀이들을 많이 보고, 코드 리팩토링을 더 열심히 해봐야겠다고 생각했다.
